### PR TITLE
Add installation instructions & llama.cpp as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/llama.cpp"]
+	path = third_party/llama.cpp
+	url = https://github.com/ggml-org/llama.cpp.git

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ This repository bridges that gap by providing DASLab's state-of-the-art model co
 
 The toolkit enables researchers and practitioners to move beyond uniform quantization, systematically exploring mixed-precision configurations that achieve better quality-compression tradeoffs. By bringing advanced compression research to the GGUF ecosystem, we aim to democratize access to efficient, high-quality quantized models.
 
+## Installation
+
+```
+# install uv (first time only)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+# create a fresh project -- 3.12 supported
+uv venv --python 3.12 
+source .venv/bin/activate
+uv pip install -r requirements.txt
+```
+
+
 ## Workflow Overview
 
 The toolkit follows a three-stage pipeline for optimized GGUF quantization, creating the database for the search, searching and reassambling the model from the found configuration. 
@@ -549,23 +561,6 @@ Several directions could enhance the toolkit's capabilities:
 - Calibration Selection: Selecting optimal calibration datasets based on model characteristics and deployment scenarios.
 - Hardware-Aware Optimization: Integrate device-specific constraints into EvoPress search to optimize quantization for target hardware (edge devices, GPUs, etc.).
 
-
-## Environment
-
-```
-- datasets 4.0.0
-- gguf 0.17.1
-- numpy 2.3.2
-- pandas 2.3.1
-- torch 2.8.0
-- torchaudio 2.7.1
-- torchvision 0.22.1
-- tqdm 4.67.1
-- tqdm-multiprocess 0.0.11
-- transformers 4.56.0.dev0
-- lm-eval 0.4.9.1
-- wandb 0.21.0
-```
 ---
 
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ The toolkit enables researchers and practitioners to move beyond uniform quantiz
 ## Installation
 
 ```
+# clone the repo
+git clone https://github.com/IST-DASLab/gptq-gguf-toolkit.git
+cd gptq-gguf-toolki
+
+# fetch the submodules (currently llama.cpp)
+git submodule update --init --recursive
+
 # install uv (first time only)
 curl -LsSf https://astral.sh/uv/install.sh | sh
 # create a fresh project -- 3.12 supported
@@ -21,6 +28,36 @@ source .venv/bin/activate
 uv pip install -r requirements.txt
 ```
 
+### llama.cpp dependency
+
+In `quant/gguf`, quantization requires access to the `llama-quantize` binary. There are two ways to obtain it:
+
+1. Obtain the [latest built binaries](https://github.com/ggml-org/llama.cpp/releases) for your platform (Linux, MacOS, ...)
+
+```
+# example with Linux on release b6484
+wget https://github.com/ggml-org/llama.cpp/releases/download/b6484/llama-b6484-bin-ubuntu-x64.zip
+
+# you should obtain a build folder
+unzip llama-b6484-bin-ubuntu-x64.zip
+ 
+# move it to the submodule
+mv build/ third_party/llama.cpp/
+```
+
+2. If there are no binaries for your platform, you can build llama.cpp from scratch ([build guide](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md))
+
+```
+cd third_party/llama.cpp
+
+## CPU build
+cmake -B build
+cmake --build build --config Release -j 8
+
+## Hopper GPUs build
+cmake -B build -DGGML_CUDA=ON -DLLAMA_CURL=OFF -DCMAKE_CUDA_ARCHITECTURES="90" -DBUILD_SHARED_LIBS=OFF
+cmake --build build --config Release -j 8
+```
 
 ## Workflow Overview
 

--- a/quant/gguf/run_quant.sh
+++ b/quant/gguf/run_quant.sh
@@ -9,7 +9,8 @@ set -e
 DEFAULT_QUANT_TYPES="Q2_K Q3_K Q4_K Q5_K Q6_K Q8_K IQ1_S IQ2_XXS IQ2_XS IQ2_S IQ2_M IQ3_XXS IQ3_S IQ3_M IQ4_NL IQ4_XS"
 
 # Default paths
-K_QUANT_BINARY="$HOME/bin/llama/llama-quantize"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+K_QUANT_BINARY="$SCRIPT_DIR/../../third_party/llama.cpp/build/bin/llama-quantize"
 DEFAULT_OUTPUT_DIR="./quantized_models"
 
 print_status() {

--- a/quant/gptq/pack_compressed_tensors_into_gguf.py
+++ b/quant/gptq/pack_compressed_tensors_into_gguf.py
@@ -26,7 +26,10 @@ if TYPE_CHECKING:
     from torch import Tensor
 
 if 'NO_LOCAL_GGUF' not in os.environ:
-    sys.path.insert(1, str(Path(__file__).parent / 'gguf-py'))
+    gguf_py_path = Path(__file__).parents[2] / 'third_party' / 'llama.cpp' / 'gguf-py'
+    if not gguf_py_path.exists():
+        raise FileNotFoundError(f"GGUF Python bindings not found at {gguf_py_path}")
+    sys.path.insert(1, str(gguf_py_path))
 import gguf
 from gguf.vocab import MistralTokenizerType, MistralVocab
 from mistral_common.tokens.tokenizers.base import TokenizerVersion

--- a/quant/gptq/pack_gptq_into_gguf.py
+++ b/quant/gptq/pack_gptq_into_gguf.py
@@ -26,7 +26,10 @@ if TYPE_CHECKING:
     from torch import Tensor
 
 if 'NO_LOCAL_GGUF' not in os.environ:
-    sys.path.insert(1, str(Path(__file__).parent / 'gguf-py'))
+    gguf_py_path = Path(__file__).parents[2] / 'third_party' / 'llama.cpp' / 'gguf-py'
+    if not gguf_py_path.exists():
+        raise FileNotFoundError(f"GGUF Python bindings not found at {gguf_py_path}")
+    sys.path.insert(1, str(gguf_py_path))
 import gguf
 from gguf.vocab import MistralTokenizerType, MistralVocab
 from mistral_common.tokens.tokenizers.base import TokenizerVersion

--- a/quant/gptq/quant.py
+++ b/quant/gptq/quant.py
@@ -127,7 +127,7 @@ def parse_args():
         "--attn_implementation",
         type=str,
         default=None,
-        choices=["eager", "sdpa", "flash_attention_2"],
+        # choices=["eager", "sdpa", "flash_attention_2"],
         help="Attention implementation for both teacher and student models: eager, sdpa, or flash_attention_2",
     )
     parser.add_argument("--cpu_offload_modules", action="store_true", help="whether to offload modules to CPU.")

--- a/quant/gptq/run_quant.sh
+++ b/quant/gptq/run_quant.sh
@@ -27,14 +27,14 @@ torchrun --nnodes=1 --nproc-per-node=$NUM_GPUS --master_port $MASTER_PORT quant.
     --rel_damp "${REL_DAMP:-0.01}" \
     --block_size "${BLOCK_SIZE:-128}" \
     --default_bit_width "${BITS:-Q4_K}" \
-    --bit_width_configuration "${BIT_WIDTH_CONFIGURATION:-./config.json}" \
     --rmin "${RMIN:--1.0}" \
     --rdelta "${RDELTA:-0.1}" \
     --nstep "${NSTEP:-20}" \
     --dtype "${DTYPE:-auto}" \
     --seed "${SEED:-0}" \
-    --attn_implementation "${ATTN_IMPL:-}" \
     --eval_perplexity \
     --eval_sequence_length "${EVAL_SEQ_LEN:-2048}" \
     --verbose \
-    --save_dir "${SAVE_DIR:-/./quantized_model}" \
+    --save_dir "${SAVE_DIR:-./quantized_model}" \
+    # --bit_width_configuration "${BIT_WIDTH_CONFIGURATION:-./config.json}" \
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ tqdm-multiprocess==0.0.11
 transformers==4.56.1
 lm-eval==0.4.9.1
 wandb==0.21.0
+sentencepiece

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+datasets
+gguf==0.17.1
+numpy==2.3.2
+pandas==2.3.1
+torch==2.8.0
+tqdm==4.67.1
+tqdm-multiprocess==0.0.11
+transformers==4.56.1
+lm-eval==0.4.9.1
+wandb==0.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 datasets
+mistral-common
 gguf==0.17.1
 numpy==2.3.2
 pandas==2.3.1


### PR DESCRIPTION
Hello, thank you very much for this toolkit. This is very useful for the community, and this PR aims to make a few improvements.

- It adds an explicit requirements.txt & installation instructions in the README.md. 
   - The current dependencies specified in the README.md don't work out of box with `pip` or `uv`.

- It adds explicitly `llama.cpp` as a submodule.
   - This allows a clear way to obtain llama binaries such as `llama-quantize` necessary for scripts such as `quant/gguf/run_quant.sh` .
   -  This also fixes import errors (e.g. `MistralTokenizerType` is not importable) when running `quant/gptq/pack_gptq_into_gguf.py`, as the pypi version of `gguf` is not up-to-date, and `llama.cpp` implictly requires to point to the local upstream version stored in the `gguf-py` folder.